### PR TITLE
Updates to reflect websocket.in V3 changes.

### DIFF
--- a/background.js
+++ b/background.js
@@ -12,8 +12,8 @@ window.notify = notify;
 const prefs = {
   name: '',
   id: '',
-  server: 'wss://connect.websocket.in/v2/1?token=[token]',
-  token: '',
+  server: 'wss://connect.websocket.in/v3/1?apiKey=[apiKey]',
+  apiKey: '',
   password: '',
   enabled: true,
   contexts: ['browser_action', 'link', 'selection']
@@ -43,13 +43,13 @@ peer.on('status', o => {
   }
 });
 chrome.browserAction.onClicked.addListener(() => {
-  if (prefs.token) {
+  if (prefs.apiKey) {
     chrome.storage.local.set({
       enabled: prefs.enabled === false
     });
   }
   else {
-    notify('For the extension to work, you need to get a free private TOKEN.');
+    notify('For the extension to work, you need to get a free private API KEY.');
     chrome.runtime.openOptionsPage();
   }
 });
@@ -354,7 +354,7 @@ chrome.storage.local.get(prefs, async ps => {
   // peer
   peer.offline = prefs.enabled === false;
   await peer.configure({
-    token: prefs.token,
+    apiKey: prefs.apiKey,
     server: prefs.server,
     password: prefs.password
   });
@@ -374,10 +374,10 @@ chrome.storage.onChanged.addListener(ps => {
   if (ps.enabled && !prefs.enabled) {
     peer.shutdown();
   }
-  if (ps.token || ps.server || ps.name || ps.password) {
-    if (ps.token) {
+  if (ps.apiKey || ps.server || ps.name || ps.password) {
+    if (ps.apiKey) {
       peer.configure({
-        token: prefs.token
+        apiKey: prefs.apiKey
       });
     }
     if (ps.server) {
@@ -391,7 +391,7 @@ chrome.storage.onChanged.addListener(ps => {
       });
     }
     //
-    if (prefs.token && prefs.enabled) {
+    if (prefs.apiKey && prefs.enabled) {
       peer.restart();
     }
     else {

--- a/data/options/index.html
+++ b/data/options/index.html
@@ -37,9 +37,9 @@
       </tbody>
     </table>
 
-    <h1>Token</h1>
-    <textarea cols="3" placeholder="Your websocket.in Token (required)" required id="token"></textarea>
-    <span>For the extension to share links and clipboard content with other computers on your network, you need to get your free and private token from <a href="https://www.websocket.in/account">websocket.in</a> and insert the token in all computers that you would like to be able to send or receive links. If you are using another WebSocket server (like your own private WSS server) that does not require a token, still fill the box with an arbitrary string.</span>
+    <h1>API Key</h1>
+    <textarea cols="3" placeholder="Your websocket.in API Key (required)" required id="apiKey"></textarea>
+    <span>For the extension to share links and clipboard content with other computers on your network, you need to get your free and private API Key from <a href="https://www.websocket.in">websocket.in</a> and insert the API Key in all computers that you would like to be able to send or receive links. If you are using another WebSocket server (like your own private WSS server) that does not require an API Key, still fill the box with an arbitrary string.</span>
 
     <p>
       <input type="button" id="reset" value="Factory Reset">

--- a/data/options/index.js
+++ b/data/options/index.js
@@ -4,13 +4,13 @@ const toast = document.getElementById('toast');
 
 chrome.storage.local.get({
   name: '',
-  token: '',
-  server: 'wss://connect.websocket.in/v2/1?token=[token]',
+  apiKey: '',
+  server: 'wss://connect.websocket.in/v3/1?apiKey=[apiKey]',
   password: ''
 }, prefs => {
   document.getElementById('name').value = prefs.name;
   document.getElementById('server').value = prefs.server;
-  document.getElementById('token').value = prefs.token;
+  document.getElementById('apiKey').value = prefs.apiKey;
   document.getElementById('password').value = prefs.password;
 });
 
@@ -20,7 +20,7 @@ document.querySelector('form').addEventListener('submit', e => {
   chrome.storage.local.set({
     name: document.getElementById('name').value,
     server: document.getElementById('server').value,
-    token: document.getElementById('token').value,
+    apiKey: document.getElementById('apiKey').value,
     password: document.getElementById('password').value
   }, () => {
     toast.textContent = 'Options Saved';

--- a/peer/peer.js
+++ b/peer/peer.js
@@ -46,7 +46,7 @@ const peer = {
     }
     catch (e) {}
 
-    const wss = this.wss = new WebSocket((peer.prefs.server).replace('[token]', peer.prefs.token));
+    const wss = this.wss = new WebSocket((peer.prefs.server).replace('[apiKey]', peer.prefs.apiKey));
     peer.log('info', 'try to create a new socket');
     wss.onopen = () => {
       peer.status = 'CONNECTED';
@@ -73,7 +73,7 @@ const peer = {
     };
   },
   validate() {
-    return peer.prefs.token && peer.offline === false && navigator.onLine && peer.status === 'DISCONNECTED';
+    return peer.prefs.apiKey && peer.offline === false && navigator.onLine && peer.status === 'DISCONNECTED';
   },
   connect(reason) {
     peer.log('info', `try to connect "${reason}"`);
@@ -121,9 +121,9 @@ const peer = {
   async configure(ps) {
     peer.prefs = Object.assign(peer.prefs || {
       password: '', // if provided, all the data will be encrypted using this password
-      token: '',
+      apiKey: '',
       channel: 1,
-      server: 'wss://connect.websocket.in/v2/',
+      server: 'wss://connect.websocket.in/v3/',
       reconnect: [1000, 2000, 5000, 10000, 40000],
       iceServers: [{
         'url': 'stun:stun.services.mozilla.com'


### PR DESCRIPTION
Hi Brian,

Great addon/extension. Finding it very useful copying and pasting stuff between a remote desktop I have no copy/paste permissions on while this whole working from home thing is happening.

I noticed that websocket.in finally had an overhaul from v2 to v3 and as such it "broke" things working natively. As such, I've created this pull request.

It simply fixes references to websocket.in v2 and all references of Token are now apiKey.

I hope it's helpful!

Keep up the good work :) 

Ryan